### PR TITLE
Add macOS App Groups Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,17 @@ You also need to add Keychain Sharing as capability to your macOS runner. To ach
 <array/>
 ```
 
+If you have set your application up to use App Groups then you will need to add the name of the App Group to the `keychain-access-groups` argument above. Failure to do so will result in values appearing to be written successfully but never actually being written at all. For example if your app has an App Group named "aoeu" then your value for above would instead read:
+
+```
+<key>keychain-access-groups</key>
+<array>
+	<string>$(AppIdentifierPrefix)aoeu</string>
+</array>
+```
+
+If you are configuring this value through XCode then the string you set in the Keychain Sharing section would simply read "aoeu" with XCode appending the `$(AppIdentifierPrefix)` when it saves the configuration.
+
 ### Configure Windows Version
 
 You need the C++ ATL libraries installed along with the rest of Visual Studio Build Tools. Download them from [here](https://visualstudio.microsoft.com/downloads/?q=build+tools) and make sure the C++ ATL under optional is installed as well.


### PR DESCRIPTION
I was having problems getting this working with a macOS app that was using App Groups. These new added instructions are how I was able to finally get this working. This may also be an issue with iOS but I haven't tested under those conditions.